### PR TITLE
Fix viewer badge placement on home and list view screens

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -184,6 +184,12 @@ Text(AppLocalizations.of(context)!.aiFeatures)
 - Clearing completed items must move items from `lists/{listId}/items` to `lists/{listId}/recycled_items` with deletion metadata (`deletedAt`, `deletedBy`, `deletedByName`) rather than hard deleting.
 - Keep behavior consistent by reusing the shared dialog (`lib/widgets/lists/clear_completed_dialog.dart`) and data logic (`lib/services/data/completed_items_service.dart`).
 
+9. **Viewer Badge Placement**:
+
+- Do not show a global viewer badge on the home screen based on `hasViewerLists()`.
+- Show the viewer badge only inside a specific list screen when `PermissionsHelper.isViewer(listId)` is true for that list.
+- Render the badge in normal layout flow between list content and navigation UI (not as an overlay) so list content is never hidden behind it.
+
 ### Authentication
 
 - Google Sign-In uses **Credential Manager** on Android (v2.0.0 API) for passkey support

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -24,7 +24,6 @@ import '/widgets/user/user_avatar.dart';
 import '/services/data/list_groups_service.dart';
 import '/services/data/gravatar_service.dart';
 import '/services/migration/migration_service.dart';
-import '/utils/permissions.dart';
 
 class TutorialStep extends StatelessWidget {
   final IconData icon;
@@ -1346,45 +1345,6 @@ class _HomeScreenState extends State<HomeScreen>
                     ),
                   ],
                 ),
-              ),
-              // Viewer indicator
-              FutureBuilder<bool>(
-                future: PermissionsHelper.hasViewerLists(),
-                builder: (context, snapshot) {
-                  if (snapshot.hasData && snapshot.data == true) {
-                    return Container(
-                      margin: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 8),
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: isDark ? Colors.blue[900] : Colors.blue[50],
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: isDark ? Colors.blue[700]! : Colors.blue[200]!,
-                        ),
-                      ),
-                      child: Row(
-                        children: [
-                          Icon(
-                            Icons.visibility,
-                            color: isDark ? Colors.blue[300] : Colors.blue[700],
-                            size: 16,
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            l10n.homeYouAreAViewer,
-                            style: TextStyle(
-                              color:
-                                  isDark ? Colors.blue[300] : Colors.blue[700],
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  return const SizedBox.shrink();
-                },
               ),
               // Advertisement at the bottom
               if (_isBannerAdLoaded && _bannerAd != null)

--- a/lib/screens/lists/list_view.dart
+++ b/lib/screens/lists/list_view.dart
@@ -164,6 +164,38 @@ class _ListViewScreenState extends State<ListViewScreen>
     }
   }
 
+  Widget _buildViewerBadge({required bool isDark, required String label}) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isDark ? Colors.blue[900] : Colors.blue[50],
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isDark ? Colors.blue[700]! : Colors.blue[200]!,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.visibility,
+            color: isDark ? Colors.blue[300] : Colors.blue[700],
+            size: 16,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(
+              color: isDark ? Colors.blue[300] : Colors.blue[700],
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -171,7 +203,7 @@ class _ListViewScreenState extends State<ListViewScreen>
     final screenWidth = MediaQuery.of(context).size.width;
     final isDesktopOrTablet = screenWidth >= 600; // Tablets and desktop
 
-    final body = AnimatedSwitcher(
+    final content = AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),
       switchInCurve: Curves.easeInOut,
       switchOutCurve: Curves.easeInOut,
@@ -181,6 +213,23 @@ class _ListViewScreenState extends State<ListViewScreen>
         key: ValueKey(_selectedIndex),
         child: _buildTabContent(_selectedIndex),
       ),
+    );
+
+    final bodyWithViewerBadge = FutureBuilder<bool>(
+      future: _isViewerFuture,
+      builder: (context, snapshot) {
+        final isViewer = snapshot.data == true;
+        return Column(
+          children: [
+            Expanded(child: content),
+            if (isViewer)
+              _buildViewerBadge(
+                isDark: isDark,
+                label: l10n.homeYouAreAViewer,
+              ),
+          ],
+        );
+      },
     );
 
     Widget? fab = _selectedIndex == 0
@@ -388,10 +437,10 @@ class _ListViewScreenState extends State<ListViewScreen>
                 ),
                 const VerticalDivider(thickness: 1, width: 1),
                 // Main content
-                Expanded(child: body),
+                Expanded(child: bodyWithViewerBadge),
               ],
             )
-          : body,
+          : bodyWithViewerBadge,
       bottomNavigationBar: isDesktopOrTablet
           ? null
           : Theme(

--- a/lib/screens/lists/list_view.dart
+++ b/lib/screens/lists/list_view.dart
@@ -184,13 +184,17 @@ class _ListViewScreenState extends State<ListViewScreen>
             size: 16,
           ),
           const SizedBox(width: 8),
-          Text(
-            label,
-            style: TextStyle(
-              color: isDark ? Colors.blue[300] : Colors.blue[700],
-              fontWeight: FontWeight.w500,
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(
+                color: isDark ? Colors.blue[300] : Colors.blue[700],
+                fontWeight: FontWeight.w500,
+              ),
             ),
           ),
+        ],
+      ),
         ],
       ),
     );

--- a/lib/utils/permissions.dart
+++ b/lib/utils/permissions.dart
@@ -52,34 +52,4 @@ class PermissionsHelper {
       return 'viewer';
     }
   }
-
-  /// Check if current user has any viewer-only lists
-  static Future<bool> hasViewerLists() async {
-    final currentUserId = _auth.currentUser?.uid;
-    if (currentUserId == null) return false;
-
-    try {
-      final listsSnapshot = await _firestore
-          .collection('lists')
-          .where('members', arrayContains: currentUserId)
-          .get();
-
-      for (final doc in listsSnapshot.docs) {
-        final data = doc.data();
-
-        // Skip if user is the owner
-        if (data['createdBy'] == currentUserId) continue;
-
-        // Check member role
-        final memberRoles = Map<String, String>.from(data['memberRoles'] ?? {});
-        final userRole = memberRoles[currentUserId] ?? 'viewer';
-
-        if (userRole == 'viewer') return true;
-      }
-
-      return false;
-    } catch (e) {
-      return false;
-    }
-  }
 }


### PR DESCRIPTION
This pull request updates how the "viewer" badge is displayed in the app. Instead of showing a global viewer badge on the home screen, the badge is now shown only inside a specific list screen when the user is a viewer of that list. The badge is rendered within the normal layout flow, ensuring it does not overlay or hide list content. The implementation for checking global viewer status and displaying the badge on the home screen has been removed.

**Viewer Badge Placement and Logic:**

* Removed the global viewer badge from the home screen and the associated logic for checking if the user has any viewer-only lists (`PermissionsHelper.hasViewerLists()`). [[1]](diffhunk://#diff-3c4164a8346a87854665f200ffb80f341d7b09f063ca86e40d8d6f6dd1109509L1350-L1388) [[2]](diffhunk://#diff-422007d5b0b1f7f0fdb563bb313c8b3d1337122a3870c78b8e4e160134978703L55-L84)
* Added logic to display the viewer badge only inside a specific list screen, using a new `_buildViewerBadge` widget and a `FutureBuilder` that checks viewer status for the current list. [[1]](diffhunk://#diff-4c01c0ac9e7ff09ba4d400f94445b1df0623e99fe4b65b4491fb1966b7fa52c6R167-R206) [[2]](diffhunk://#diff-4c01c0ac9e7ff09ba4d400f94445b1df0623e99fe4b65b4491fb1966b7fa52c6R218-R234) [[3]](diffhunk://#diff-4c01c0ac9e7ff09ba4d400f94445b1df0623e99fe4b65b4491fb1966b7fa52c6L391-R443)

**Documentation:**

* Updated `.github/copilot-instructions.md` to describe the new viewer badge placement rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Viewer badge now appears on individual list screens instead of the home screen for better context
  * Badge renders in the normal content layout, preventing any overlap with list information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->